### PR TITLE
Add automatic mypy stub package synchronization to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v1.11.2
     hooks:
       - id: mypy
-        entry: uv run mypy
+        entry: python scripts/mypy_with_stub_sync.py
         args:
           [
             --explicit-package-bases

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,78 @@
+# Scripts Directory
+
+This directory contains utility scripts for the chess-eval project.
+
+## mypy_with_stub_sync.py
+
+A wrapper script for mypy that automatically adds missing type stub packages to `pyproject.toml`.
+
+### Problem Statement
+
+When mypy runs and discovers it needs type stubs (e.g., `types-requests`, `pandas-stubs`), it automatically installs them into the virtual environment. However, these packages are not reflected in `pyproject.toml`, which can lead to:
+
+- Inconsistencies between development environments
+- Missing dependencies when setting up the project fresh
+- Manual tracking of stub packages
+
+### Solution
+
+This script wraps mypy execution and:
+
+1. Runs mypy with all the same arguments
+2. Monitors mypy's output for stub package installations
+3. Automatically adds discovered stub packages to `pyproject.toml` using `uv add --dev`
+4. Maintains proper dependency tracking without slowing down pre-commit
+
+### How It Works
+
+1. The script runs mypy and streams its output in real-time
+2. It parses the output for patterns indicating stub package installations
+3. After mypy completes, it extracts the package names
+4. It runs `uv add --dev <package>` for each discovered stub package
+5. The script returns mypy's exit code, so pre-commit workflows work correctly
+
+### Integration
+
+The script is integrated into the pre-commit workflow via `.pre-commit-config.yaml`:
+
+```yaml
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+    - id: mypy
+      entry: python scripts/mypy_with_stub_sync.py
+      args:
+        [
+          --explicit-package-bases
+        ]
+```
+
+### Benefits
+
+- **No Performance Penalty**: Mypy runs only once (no dry runs)
+- **Automatic Dependency Management**: Stub packages are added to `pyproject.toml` automatically
+- **Consistent Environments**: All developers get the same type stubs
+- **Works with uv/poetry**: Uses `uv add` to properly manage dependencies
+- **Dev Group**: Stubs are correctly added to the dev dependency group
+
+### Usage
+
+The script is automatically invoked by pre-commit. If you need to run it manually:
+
+```bash
+python scripts/mypy_with_stub_sync.py [mypy-args]
+```
+
+For example:
+
+```bash
+python scripts/mypy_with_stub_sync.py --explicit-package-bases chess_eval/
+```
+
+### Note
+
+When the script adds packages to `pyproject.toml`, you'll see a message indicating which packages were added. You may need to stage the updated `pyproject.toml` and `uv.lock` files:
+
+```bash
+git add pyproject.toml uv.lock
+```

--- a/scripts/mypy_with_stub_sync.py
+++ b/scripts/mypy_with_stub_sync.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Mypy wrapper that automatically adds missing type stubs to pyproject.toml.
+
+This script runs mypy and monitors its output for stub package installations.
+When mypy installs stub packages, they are automatically added to the
+pyproject.toml dev dependency group using `uv add --dev`.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Set
+
+
+def parse_stub_packages_from_output(output: str) -> Set[str]:
+    """
+    Parse mypy output to extract stub package names.
+
+    Mypy outputs messages like:
+    - "Installing missing stub packages:"
+    - "/path/to/python -m pip install types-foo"
+    - Or suggests: "python3 -m pip install types-foo"
+    """
+    stub_packages: Set[str] = set()
+
+    # Pattern to match pip install commands for stub packages
+    # Matches: pip install types-foo, pip install pandas-stubs, etc.
+    pip_install_pattern = re.compile(r'pip install\s+((?:types-|.*-stubs)\S+)', re.MULTILINE)
+
+    # Find all stub packages mentioned in pip install commands
+    for match in pip_install_pattern.finditer(output):
+        package = match.group(1)
+        # Remove version specifiers if any (e.g., types-foo>=1.0.0 -> types-foo)
+        package = re.split(r'[>=<\[]', package)[0]
+        stub_packages.add(package)
+
+    return stub_packages
+
+
+def add_stubs_to_pyproject(stub_packages: Set[str], project_root: Path) -> None:
+    """
+    Add stub packages to pyproject.toml dev dependency group using uv.
+
+    Args:
+        stub_packages: Set of stub package names to add
+        project_root: Path to the project root directory
+    """
+    if not stub_packages:
+        return
+
+    print("\n" + "=" * 70)
+    print("Mypy installed new stub packages. Adding them to pyproject.toml...")
+    print("=" * 70)
+
+    for package in sorted(stub_packages):
+        print(f"Adding {package} to dev dependencies...")
+        try:
+            result = subprocess.run(
+                ["uv", "add", "--dev", package],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            if result.returncode == 0:
+                print(f"  ✓ {package} added successfully")
+            else:
+                print(f"  ✗ Failed to add {package}: {result.stderr.strip()}")
+        except subprocess.TimeoutExpired:
+            print(f"  ✗ Timeout while adding {package}")
+        except Exception as e:
+            print(f"  ✗ Error adding {package}: {e}")
+
+    print("=" * 70)
+    print("Note: pyproject.toml has been updated. You may need to stage the changes.")
+    print("=" * 70 + "\n")
+
+
+def run_mypy_with_monitoring(args: List[str], project_root: Path) -> int:
+    """
+    Run mypy with the given arguments and monitor for stub installations.
+
+    Args:
+        args: Command line arguments to pass to mypy
+        project_root: Path to the project root directory
+
+    Returns:
+        Exit code from mypy
+    """
+    # Run mypy via uv
+    cmd = ["uv", "run", "mypy"] + args
+
+    try:
+        # Run mypy and capture output in real-time
+        process = subprocess.Popen(
+            cmd,
+            cwd=project_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1
+        )
+
+        # Collect output while streaming to console
+        full_output = []
+        if process.stdout:
+            for line in process.stdout:
+                # Print line immediately so user sees progress
+                print(line, end='')
+                full_output.append(line)
+
+        # Wait for process to complete
+        return_code = process.wait()
+
+        # Parse collected output for stub packages
+        output_text = ''.join(full_output)
+        stub_packages = parse_stub_packages_from_output(output_text)
+
+        # Add any discovered stub packages to pyproject.toml
+        if stub_packages:
+            add_stubs_to_pyproject(stub_packages, project_root)
+
+        return return_code
+
+    except FileNotFoundError:
+        print("Error: 'uv' command not found. Please ensure uv is installed.", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error running mypy: {e}", file=sys.stderr)
+        return 1
+
+
+def main() -> int:
+    """Main entry point."""
+    # Get project root (parent of scripts directory)
+    script_path = Path(__file__).resolve()
+    project_root = script_path.parent.parent
+
+    # Pass all command line arguments to mypy
+    mypy_args = sys.argv[1:]
+
+    return run_mypy_with_monitoring(mypy_args, project_root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This commit implements a solution to automatically add type stub packages to pyproject.toml when they are installed by mypy during pre-commit.

Changes:
- Created scripts/mypy_with_stub_sync.py: A wrapper script that monitors mypy output for stub package installations and automatically adds them to the dev dependency group using `uv add --dev`
- Updated .pre-commit-config.yaml: Modified mypy hook to use the wrapper script instead of direct `uv run mypy` invocation
- Added scripts/README.md: Documentation explaining the solution and how it works

Benefits:
- No performance penalty: mypy runs only once (no dry runs)
- Automatic dependency management: stub packages are added to pyproject.toml
- Consistent development environments across all team members
- Proper integration with uv/poetry workflow
- Type stubs correctly added to dev dependency group

The wrapper script parses mypy output, detects newly installed stub packages, and updates pyproject.toml automatically, ensuring that type dependencies are properly tracked in version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)